### PR TITLE
Update URL reference in source code from Bitbucket to Github

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 Cervantes e-book reader application
 Copyright (C) 2011-2013  Mundoreader, S.L
-ssh://hg@bitbucket.org/mundoreader/cervantes
+ssh://git@github.com:bq/cervantes.git
 
 WHAT IS IT?
 -----------

--- a/bqSetting/tr/bqSetting_ca.ts
+++ b/bqSetting/tr/bqSetting_ca.ts
@@ -162,8 +162,8 @@
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="142"/>
-        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://bitbucket.org/mundoreader/cervantes).</source>
-        <translation>Aquesta versió de firmware ha estat desenvolupada íntegrament a Espanya per Mundo Reader S.L. per un equip de joves professionals, enginyers informàtics, de telecomunicació, dissenyadors gràfics... i publicada sota llicència GPL (https://bitbucket.org/mundoreader/cervantes).</translation>
+        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://github.com/bq/cervantes).</source>
+        <translation>Aquesta versió de firmware ha estat desenvolupada íntegrament a Espanya per Mundo Reader S.L. per un equip de joves professionals, enginyers informàtics, de telecomunicació, dissenyadors gràfics... i publicada sota llicència GPL (https://github.com/bq/cervantes).</translation>
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="155"/>

--- a/bqSetting/tr/bqSetting_de.ts
+++ b/bqSetting/tr/bqSetting_de.ts
@@ -98,8 +98,8 @@
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="142"/>
-        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://bitbucket.org/mundoreader/cervantes).</source>
-        <translation>Diese Firmware-Version wurde vollständig in Spanien von einem jungen professionellen Team aus IT-Experten, Telekommunikationsingenieuren und Grafikdesignern der Firma Mundo Reader S.L. entwickelt und unter GPL-Lizenz veröffentlicht (https://bitbucket.org/mundoreader/cervantes).</translation>
+        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://github.com/bq/cervantes).</source>
+        <translation>Diese Firmware-Version wurde vollständig in Spanien von einem jungen professionellen Team aus IT-Experten, Telekommunikationsingenieuren und Grafikdesignern der Firma Mundo Reader S.L. entwickelt und unter GPL-Lizenz veröffentlicht (https://github.com/bq/cervantes).</translation>
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="155"/>

--- a/bqSetting/tr/bqSetting_en.ts
+++ b/bqSetting/tr/bqSetting_en.ts
@@ -166,8 +166,8 @@
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="142"/>
-        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://bitbucket.org/mundoreader/cervantes).</source>
-        <translation>This firmware version has been designed by Mundo Reader S.L. entirely in Spain, by a team of young professional computer engineers, telecoms engineers, graphic designers... and published under a GPL (https://bitbucket.org/mundoreader/cervantes).</translation>
+        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://github.com/bq/cervantes).</source>
+        <translation>This firmware version has been designed by Mundo Reader S.L. entirely in Spain, by a team of young professional computer engineers, telecoms engineers, graphic designers... and published under a GPL (https://github.com/bq/cervantes).</translation>
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="155"/>

--- a/bqSetting/tr/bqSetting_es.ts
+++ b/bqSetting/tr/bqSetting_es.ts
@@ -990,8 +990,8 @@
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="142"/>
-        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://bitbucket.org/mundoreader/cervantes).</source>
-        <translation>Esta versión de firmware ha sido desarrollada íntegramente en España por Mundo Reader S.L. con un equipo de jóvenes profesionales, ingenieros informáticos, de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL (https://bitbucket.org/mundoreader/cervantes).</translation>
+        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://github.com/bq/cervantes).</source>
+        <translation>Esta versión de firmware ha sido desarrollada íntegramente en España por Mundo Reader S.L. con un equipo de jóvenes profesionales, ingenieros informáticos, de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL (https://github.com/bq/cervantes).</translation>
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="155"/>

--- a/bqSetting/tr/bqSetting_eu.ts
+++ b/bqSetting/tr/bqSetting_eu.ts
@@ -166,8 +166,8 @@
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="142"/>
-        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://bitbucket.org/mundoreader/cervantes).</source>
-        <translation>Firmware bertsio oso hau Mundo Reader S.L-k diseinatu du Espainian, gazte profesional talde batekin,telekomunikazioko ingeniari informatikoak, diseinatzaile grafikoak… eta GPL lizentzia pean publikatua (https://bitbucket.org/mundoreader/cervantes).</translation>
+        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://github.com/bq/cervantes).</source>
+        <translation>Firmware bertsio oso hau Mundo Reader S.L-k diseinatu du Espainian, gazte profesional talde batekin,telekomunikazioko ingeniari informatikoak, diseinatzaile grafikoak… eta GPL lizentzia pean publikatua (https://github.com/bq/cervantes).</translation>
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="155"/>

--- a/bqSetting/tr/bqSetting_fr.ts
+++ b/bqSetting/tr/bqSetting_fr.ts
@@ -96,8 +96,8 @@
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="142"/>
-        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://bitbucket.org/mundoreader/cervantes).</source>
-        <translation>Cette version de micrologiciel a été développée intégralement en Espagne par Mundo Reader S.L. grâce à une équipe de jeunes professionnels, d&apos;ingénieurs informatiques des télécommunications, d&apos;infographistes... et publiée sous une licence GNU (https://bitbucket.org/mundoreader/cervantes).</translation>
+        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://github.com/bq/cervantes).</source>
+        <translation>Cette version de micrologiciel a été développée intégralement en Espagne par Mundo Reader S.L. grâce à une équipe de jeunes professionnels, d&apos;ingénieurs informatiques des télécommunications, d&apos;infographistes... et publiée sous une licence GNU (https://github.com/bq/cervantes).</translation>
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="155"/>

--- a/bqSetting/tr/bqSetting_gl.ts
+++ b/bqSetting/tr/bqSetting_gl.ts
@@ -96,8 +96,8 @@
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="142"/>
-        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://bitbucket.org/mundoreader/cervantes).</source>
-        <translation>Esta versión de firmware foi desenvolta íntegramente en España por Mundo Reader S.L. cun equipo de xoves profesionais, enxeñeiros informáticos, de telecomunicación, deseñadores gráficos... e publicada baixo licencia GPL (https://bitbucket.org/mundoreader/cervantes).</translation>
+        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://github.com/bq/cervantes).</source>
+        <translation>Esta versión de firmware foi desenvolta íntegramente en España por Mundo Reader S.L. cun equipo de xoves profesionais, enxeñeiros informáticos, de telecomunicación, deseñadores gráficos... e publicada baixo licencia GPL (https://github.com/bq/cervantes).</translation>
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="155"/>

--- a/bqSetting/tr/bqSetting_it.ts
+++ b/bqSetting/tr/bqSetting_it.ts
@@ -96,8 +96,8 @@
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="142"/>
-        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://bitbucket.org/mundoreader/cervantes).</source>
-        <translation type="unfinished">Questa versione del firmware è stata sviluppata interamente in Spagna da Mundo Reader S.L. con un team di giovani professionisti, ingegneri informatici e delle telecomunicazioni, disegnatori grafici, etc. e pubblicata con licenza GPL (https://bitbucket.org/mundoreader/cervantes).</translation>
+        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://github.com/bq/cervantes).</source>
+        <translation type="unfinished">Questa versione del firmware è stata sviluppata interamente in Spagna da Mundo Reader S.L. con un team di giovani professionisti, ingegneri informatici e delle telecomunicazioni, disegnatori grafici, etc. e pubblicata con licenza GPL (https://github.com/bq/cervantes).</translation>
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="155"/>

--- a/bqSetting/tr/bqSetting_pt.ts
+++ b/bqSetting/tr/bqSetting_pt.ts
@@ -166,8 +166,8 @@
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="142"/>
-        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://bitbucket.org/mundoreader/cervantes).</source>
-        <translation>Esta versão de firmware foi integralmente desenvolvida em Espanha pela Mundo Reader S.L.,com uma equipa de jovens profissionais, engenheiros informáticos, de telecomunicações, desenhadores gráfico... e publicada sob licença GPL (https://bitbucket.org/mundoreader/cervantes).</translation>
+        <source>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://github.com/bq/cervantes).</source>
+        <translation>Esta versão de firmware foi integralmente desenvolvida em Espanha pela Mundo Reader S.L.,com uma equipa de jovens profissionais, engenheiros informáticos, de telecomunicações, desenhadores gráfico... e publicada sob licença GPL (https://github.com/bq/cervantes).</translation>
     </message>
     <message utf8="true">
         <location filename="../ui/SettingsAboutUs.ui" line="155"/>

--- a/bqSetting/ui/SettingsAboutUs.ui
+++ b/bqSetting/ui/SettingsAboutUs.ui
@@ -139,7 +139,7 @@
       <item>
        <widget class="QLabel" name="firmwareIntroLbl">
         <property name="text">
-         <string>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://bitbucket.org/mundoreader/cervantes).</string>
+         <string>Esta versión de firmware ha sido desarrollada integramente en España por Mundo Reader S.L. con un quipo de jóvenes profesionales, ingenieros informáticos de telecomunicación, diseñadores gráficos ... y publicada bajo licencia GPL  (https://github.com/bq/cervantes).</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>


### PR DESCRIPTION
This pull request just update all the URL references in code to Bitbucket (dead link) to the new reference in Github.

It can easily achieved with the following command:

```
grep -ril bitbucket . | xargs sed -i 's@https://bitbucket.org/mundoreader/cervantes@https://github.com/bq/cervantes@g'
```

I am user of a BQ Cervantes and when I see the "About" page with the dead link for the source code was a bit sad, fortunally I found this repository, so I am trying to help to avoid that other users feel the same when they see a dead link.

I would thank you if you can build and deploy a quick build with this change. Thanks!
