### PR TITLE
Guard dictionary visibility check in hacker's edition

### DIFF
--- a/bqViewer/src/Viewer.cpp
+++ b/bqViewer/src/Viewer.cpp
@@ -1316,7 +1316,9 @@ void Viewer::customEvent(QEvent* received)
         return;
     }
 
+#ifndef HACKERS_EDITION
     if (m_viewerDictionary->isVisible()) return;
+#endif
 
     processTouchEvent(static_cast<TouchEvent*>(received));
 }


### PR DESCRIPTION
Using unintialized pointer leads to segmentation fault in developer's
firmware when turning pages of the book

    QBookApp: 13:37:38.232 Debug: MouseFilter::TouchEventType MouseFilter::getTouchType() ELAPSED 228 ms, MOVED  QPoint(-923,101)
    QBookApp: 13:37:38.235 Debug: virtual bool MouseFilter::eventFilter(QObject*, QEvent*) RELEASE-TAP/SWIPE
    Segmentation fault